### PR TITLE
Add license to src directory, and to mapml.js so that the eventual build

### DIFF
--- a/src/LICENSE.js
+++ b/src/LICENSE.js
@@ -1,0 +1,40 @@
+/* 
+ * Copyright 2015-2016 Canada Centre for Mapping and Earth Observation, 
+ * Earth Sciences Sector, Natural Resources Canada.
+ * 
+ * License
+ * 
+ * By obtaining and/or copying this work, you (the licensee) agree that you have 
+ * read, understood, and will comply with the following terms and conditions.
+ * 
+ * Permission to copy, modify, and distribute this work, with or without 
+ * modification, for any purpose and without fee or royalty is hereby granted, 
+ * provided that you include the following on ALL copies of the work or portions 
+ * thereof, including modifications:
+ * 
+ * The full text of this NOTICE in a location viewable to users of the 
+ * redistributed or derivative work.
+ * 
+ * Any pre-existing intellectual property disclaimers, notices, or terms and 
+ * conditions. If none exist, the W3C Software and Document Short Notice should 
+ * be included.
+ * 
+ * Notice of any changes or modifications, through a copyright statement on the 
+ * new code or document such as "This software or document includes material 
+ * copied from or derived from [title and URI of the W3C document]. 
+ * Copyright © [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)."
+ * 
+ * Disclaimers
+ * 
+ * THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS 
+ * OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF 
+ * MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE 
+ * SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, 
+ * TRADEMARKS OR OTHER RIGHTS.
+ * COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR 
+ * CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+ * 
+ * The name and trademarks of copyright holders may NOT be used in advertising or 
+ * publicity pertaining to the work without specific, written prior permission. 
+ * Title to copyright in this work will at all times remain with copyright holders.
+ */

--- a/src/mapml.js
+++ b/src/mapml.js
@@ -1,3 +1,43 @@
+/* 
+ * Copyright 2015-2016 Canada Centre for Mapping and Earth Observation, 
+ * Earth Sciences Sector, Natural Resources Canada.
+ * 
+ * License
+ * 
+ * By obtaining and/or copying this work, you (the licensee) agree that you have 
+ * read, understood, and will comply with the following terms and conditions.
+ * 
+ * Permission to copy, modify, and distribute this work, with or without 
+ * modification, for any purpose and without fee or royalty is hereby granted, 
+ * provided that you include the following on ALL copies of the work or portions 
+ * thereof, including modifications:
+ * 
+ * The full text of this NOTICE in a location viewable to users of the 
+ * redistributed or derivative work.
+ * 
+ * Any pre-existing intellectual property disclaimers, notices, or terms and 
+ * conditions. If none exist, the W3C Software and Document Short Notice should 
+ * be included.
+ * 
+ * Notice of any changes or modifications, through a copyright statement on the 
+ * new code or document such as "This software or document includes material 
+ * copied from or derived from [title and URI of the W3C document]. 
+ * Copyright © [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)."
+ * 
+ * Disclaimers
+ * 
+ * THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS 
+ * OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF 
+ * MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE 
+ * SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, 
+ * TRADEMARKS OR OTHER RIGHTS.
+ * COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR 
+ * CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+ * 
+ * The name and trademarks of copyright holders may NOT be used in advertising or 
+ * publicity pertaining to the work without specific, written prior permission. 
+ * Title to copyright in this work will at all times remain with copyright holders.
+ */
 /* global L, Node */
 (function (window, document, undefined) {
   


### PR DESCRIPTION
contains a license header for each component appropriate to the part.
Specifically so mapml.js has a CCMEO copyright/disclaimer and the URI.js
has the copyright / disclaimer that came with it.